### PR TITLE
Fix bug with superscript and other irregular digits

### DIFF
--- a/typo/keyboardlayouts/en_default.py
+++ b/typo/keyboardlayouts/en_default.py
@@ -112,7 +112,7 @@ def get_random_neighbor(char, seed=None):
     if len(char) != 1:
         raise Exception("Need exactly one character to find a neighbor")
 
-    if char.isdigit():
+    if char.isdecimal():
         numpad = random.choice([True, False])
         if numpad:
             return random.choice(NEIGHBORINGNUMPADDIGITS[char])


### PR DESCRIPTION
According to python documentation 

https://docs.python.org/3/library/stdtypes.html

isdigit()
Return True if all characters in the string are digits and there is at least one character, False otherwise. Digits include decimal characters and digits that need special handling, such as the compatibility superscript digits. This covers digits which cannot be used to form numbers in base 10, like the Kharosthi numbers. Formally, a digit is a character that has the property value Numeric_Type=Digit or Numeric_Type=Decimal.

So with current implementation there's a bug with applying extra char to '²'

Since you are using int to convert chat to a number you should use 

isdecimal()
Return True if all characters in the string are decimal characters and there is at least one character, False otherwise. Decimal characters are those that can be used to form numbers in base 10, e.g. U+0660, ARABIC-INDIC DIGIT ZERO. Formally a decimal character is a character in the Unicode General Category “Nd”.